### PR TITLE
check that alert exists in alert container

### DIFF
--- a/src/alert-container/AlertContainer.js
+++ b/src/alert-container/AlertContainer.js
@@ -73,7 +73,7 @@ class AlertContainer extends Component {
     this.setState(prevState => ({
       alerts: prevState.alerts.filter(alert => alert.id !== id)
     }))
-    alertRemoved.onClose && alertRemoved.onClose()
+    alertRemoved && alertRemoved.onClose && alertRemoved.onClose()
   }
 
   render () {

--- a/src/alert-container/AlertContainer.spec.js
+++ b/src/alert-container/AlertContainer.spec.js
@@ -148,5 +148,22 @@ describe('AlertContainer', () => {
       expect(instance.state.alerts).toHaveLength(0)
       expect(onCloseFn).toHaveBeenCalled()
     })
+
+    test('should not call close function if alert is manually closed', () => {
+      const wrapper = shallow(<AlertContainer />)
+      const instance = wrapper.instance()
+      const onCloseFn = jest.fn()
+
+      expect(instance.state.alerts).toHaveLength(0)
+      instance.show('Some message', { onClose: onCloseFn })
+      expect(instance.state.alerts).toHaveLength(1)
+      instance._removeAlert(instance.state.alerts[0].id)
+
+      onCloseFn.mockReset()
+      
+      instance._removeAlert('deleted id')
+      expect(instance.state.alerts).toHaveLength(0)
+      expect(onCloseFn).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
in reference to issue #27, added the check for the existence of `alertRemoved` before checking if `alertRemoved` has an `onClose` property. This solves the error 

> Uncaught TypeError: Cannot read property 'onClose' of undefined

for when the error is manually closed.