### PR TITLE
Expose method to remove a specific alert

### DIFF
--- a/src/alert-container/AlertContainer.js
+++ b/src/alert-container/AlertContainer.js
@@ -33,17 +33,17 @@ class AlertContainer extends Component {
 
   success = (message = '', options = {}) => {
     options.type = 'success'
-    this.show(message, options)
+    return this.show(message, options)
   }
 
   error = (message = '', options = {}) => {
     options.type = 'error'
-    this.show(message, options)
+    return this.show(message, options)
   }
 
   info = (message = '', options = {}) => {
     options.type = 'info'
-    this.show(message, options)
+    return this.show(message, options)
   }
 
   show = (message = '', options = {}) => {
@@ -60,6 +60,7 @@ class AlertContainer extends Component {
     this.setState(prevState => ({
       alerts: prevState.alerts.concat(alert)
     }))
+    return alert.id;
   }
 
   removeAll = () => {
@@ -68,7 +69,7 @@ class AlertContainer extends Component {
     alertsRemoved.forEach(alert => alert.onClose && alert.onClose())
   }
 
-  _removeAlert = id => {
+  removeAlert = id => {
     const alertRemoved = this.state.alerts.filter(alert => alert.id === id)[0]
     this.setState(prevState => ({
       alerts: prevState.alerts.filter(alert => alert.id !== id)
@@ -91,7 +92,7 @@ class AlertContainer extends Component {
               <AlertMessage
                 key={alert.id}
                 {...alert}
-                onRemoveAlert={this._removeAlert}
+                onRemoveAlert={this.removeAlert}
               />
             )
           })}

--- a/src/alert-container/AlertContainer.spec.js
+++ b/src/alert-container/AlertContainer.spec.js
@@ -135,7 +135,7 @@ describe('AlertContainer', () => {
     })
   })
 
-  describe('_removeAlert', () => {
+  describe('removeAlert', () => {
     test('should remove a given alert from state', () => {
       const wrapper = shallow(<AlertContainer />)
       const instance = wrapper.instance()
@@ -144,7 +144,7 @@ describe('AlertContainer', () => {
       expect(instance.state.alerts).toHaveLength(0)
       instance.show('Some message', { onClose: onCloseFn })
       expect(instance.state.alerts).toHaveLength(1)
-      instance._removeAlert(instance.state.alerts[0].id)
+      instance.removeAlert(instance.state.alerts[0].id)
       expect(instance.state.alerts).toHaveLength(0)
       expect(onCloseFn).toHaveBeenCalled()
     })
@@ -157,11 +157,11 @@ describe('AlertContainer', () => {
       expect(instance.state.alerts).toHaveLength(0)
       instance.show('Some message', { onClose: onCloseFn })
       expect(instance.state.alerts).toHaveLength(1)
-      instance._removeAlert(instance.state.alerts[0].id)
+      instance.removeAlert(instance.state.alerts[0].id)
 
       onCloseFn.mockReset()
       
-      instance._removeAlert('deleted id')
+      instance.removeAlert('deleted id')
       expect(instance.state.alerts).toHaveLength(0)
       expect(onCloseFn).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
In some case (when alert timeout is 0) it may be usefull to be able to remove a particular alert when an event occurs.

These changes allow to do so.