### PR TITLE
Replace shortid to nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "glamor": "^2.20.24",
     "glamorous": "^3.13.1",
-    "react-transition-group": "^1.1.2",
-    "shortid": "^2.2.8"
+    "nanoid": "^0.2.2",
+    "react-transition-group": "^1.1.2"
   }
 }

--- a/src/alert-container/AlertContainer.js
+++ b/src/alert-container/AlertContainer.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import {CSSTransitionGroup} from 'react-transition-group'
-import shortid from 'shortid'
+import nanoid from 'nanoid'
 import Container from './Container'
 import AlertMessage from '../alert'
 
@@ -52,7 +52,7 @@ class AlertContainer extends Component {
     const {theme, time} = this.props
 
     const alert = {
-      id: shortid.generate(),
+      id: nanoid(7),
       message,
       time,
       theme,


### PR DESCRIPTION
Hi. Thanks for an awesome project. I found the way how to make it a little better. By replacing unqiue ID generator from `shortid` to [`nanoid`](https://github.com/ai/nanoid).

1. `shortid` is not maintained anymore (and issue tracker has many [important issues](https://github.com/dylang/shortid/issues)). I tried to took maintenance, but found that I can’t fix `shortid` with keeping API.
2. `nanoid` is just [179 bytes](https://github.com/ai/nanoid/blob/master/package.json#L64-L67). `shortid` is 2 times bigger (about 0.5 KB).
3. `nanoid` is [10x times faster](https://github.com/ai/nanoid#benchmark) than `shortid`.

@schiehll I kept old ID size, everything will be the same for the user.