### PR TITLE
Add onOpen callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "react-alert",
-  "description": "A simple react alert component",
-  "version": "2.4.0",
+  "name": "react-alert-receptiv",
+  "description": "A Receptiv-centered component built off of react-alert",
+  "version": "0.0.1",
   "author": "Reinaldo Schiehll <rn.schiehll@gmail.com>",
   "main": "dist/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/schiehll/react-alert.git"
+    "url": "https://github.com/mperitz/react-alert.git"
   },
   "keywords": [
     "react",

--- a/src/alert-container/AlertContainer.js
+++ b/src/alert-container/AlertContainer.js
@@ -49,7 +49,6 @@ class AlertContainer extends Component {
   }
 
   show = (message = '', options = {}) => {
-    console.log('REACT-ALERT ACTIVATE!!!!')
     const {theme, time} = this.props
 
     const alert = {

--- a/src/alert-container/AlertContainer.js
+++ b/src/alert-container/AlertContainer.js
@@ -81,7 +81,6 @@ class AlertContainer extends Component {
 
   render () {
     const {position, offset, transition} = this.props
-
     return (
       <Container glam={{position, offset}}>
         <CSSTransitionGroup
@@ -89,7 +88,7 @@ class AlertContainer extends Component {
           transitionEnterTimeout={250}
           transitionLeaveTimeout={250}
         >
-          {this.state.alerts.map(alert => {
+          {this.state.alerts.map((alert) => {
             return (
               <AlertMessage
                 key={alert.id}

--- a/src/alert-container/AlertContainer.js
+++ b/src/alert-container/AlertContainer.js
@@ -49,6 +49,7 @@ class AlertContainer extends Component {
   }
 
   show = (message = '', options = {}) => {
+    console.log('REACT-ALERT ACTIVATE!!!!')
     const {theme, time} = this.props
 
     const alert = {
@@ -61,7 +62,7 @@ class AlertContainer extends Component {
 
     this.setState(prevState => ({
       alerts: prevState.alerts.concat(alert)
-    }))
+    }), () => alert.onOpen && alert.onOpen())
     return alert.id
   }
 

--- a/src/alert-container/AlertContainer.spec.js
+++ b/src/alert-container/AlertContainer.spec.js
@@ -135,6 +135,17 @@ describe('AlertContainer', () => {
       expect(instance.state.alerts[0].foo).toBe(1)
       expect(instance.state.alerts[0].bar).toBe(2)
     })
+
+    test('should call custom onOpen function if provided', () => {
+      const wrapper = shallow(<AlertContainer time={123} theme='light' />)
+      const instance = wrapper.instance()
+      const onOpenFn = jest.fn()
+
+      instance.show('custom message')
+      expect(onOpenFn).toHaveBeenCalledTimes(0)
+      instance.show('custom message', { onOpen: onOpenFn })
+      expect(onOpenFn).toHaveBeenCalled()
+    })
   })
 
   describe('removeAll', () => {

--- a/src/alert/Alert.js
+++ b/src/alert/Alert.js
@@ -7,7 +7,6 @@ const Alert = glamorous('div')({
   alignItems: 'center',
   justifyContent: 'space-between',
   fontSize: '11px',
-  
   position: 'relative',
   '&.scale-enter': {
     transform: 'scale(0)'
@@ -40,7 +39,8 @@ const Alert = glamorous('div')({
 }, props => ({
   backgroundColor: `${props.glam.dark ? '#333' : '#fff'}`,
   color: `${props.glam.dark ? '#fff' : '#333'}`,
-  boxShadow: `${props.glam.boxShadow || '0 8px 12px 0 rgba(0,0,0,0.3)'}`
+  boxShadow: `${props.glam.boxShadow || '0 8px 12px 0 rgba(0,0,0,0.3)'}`,
+  margin: `0 0 ${+(!props.glam.lastAlert)}px 0` 
 }))
 
 export default Alert

--- a/src/alert/Alert.js
+++ b/src/alert/Alert.js
@@ -3,7 +3,6 @@ import glamorous from 'glamorous/dist/glamorous.cjs.tiny'
 const Alert = glamorous('div')({
   width: '300px',
   minHeight: '50px',
-  margin: '0 0 2px 0',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',

--- a/src/alert/Alert.js
+++ b/src/alert/Alert.js
@@ -3,11 +3,10 @@ import glamorous from 'glamorous/dist/glamorous.cjs.tiny'
 const Alert = glamorous('div')({
   width: '300px',
   minHeight: '50px',
-  margin: '10px 0 0 0',
+  margin: '0 0 2px 0',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  borderRadius: '2px',
   fontSize: '11px',
   
   position: 'relative',
@@ -42,7 +41,7 @@ const Alert = glamorous('div')({
 }, props => ({
   backgroundColor: `${props.glam.dark ? '#333' : '#fff'}`,
   color: `${props.glam.dark ? '#fff' : '#333'}`,
-  boxShadow: `${props.boxShadow || '0 8px 12px 0 rgba(0,0,0,0.3)'}`
+  boxShadow: `${props.glam.boxShadow || '0 8px 12px 0 rgba(0,0,0,0.3)'}`
 }))
 
 export default Alert

--- a/src/alert/Alert.js
+++ b/src/alert/Alert.js
@@ -9,7 +9,7 @@ const Alert = glamorous('div')({
   justifyContent: 'space-between',
   borderRadius: '2px',
   fontSize: '11px',
-  boxShadow: '0 8px 12px 0 rgba(0,0,0,0.3)',
+  
   position: 'relative',
   '&.scale-enter': {
     transform: 'scale(0)'
@@ -41,7 +41,8 @@ const Alert = glamorous('div')({
   }
 }, props => ({
   backgroundColor: `${props.glam.dark ? '#333' : '#fff'}`,
-  color: `${props.glam.dark ? '#fff' : '#333'}`
+  color: `${props.glam.dark ? '#fff' : '#333'}`,
+  boxShadow: `${props.boxShadow || '0 8px 12px 0 rgba(0,0,0,0.3)'}`
 }))
 
 export default Alert

--- a/src/alert/AlertMessage.js
+++ b/src/alert/AlertMessage.js
@@ -45,15 +45,15 @@ class AlertMessage extends Component {
   }
 
   render () {
-    const {message, theme, icon, type} = this.props
+    const {message, theme, icon, type, boxShadow} = this.props
     const dark = theme === 'dark'
-
+    console.log(boxShadow)
     return (
       <Alert glam={{dark}}>
         <IconPlaceholder>
           {icon || <Icon glam={{type}} />}
         </IconPlaceholder>
-        <Message>
+        <Message glam={{boxShadow}}>
           {message}
         </Message>
         <Close

--- a/src/alert/AlertMessage.js
+++ b/src/alert/AlertMessage.js
@@ -26,6 +26,7 @@ class AlertMessage extends Component {
     type: PropTypes.oneOf(['info', 'success', 'error']),
     theme: PropTypes.oneOf(['dark', 'light']),
     time: PropTypes.number,
+    lastAlert: PropTypes.bool,
     onRemoveAlert: PropTypes.func
   }
 
@@ -45,11 +46,10 @@ class AlertMessage extends Component {
   }
 
   render () {
-    const {message, theme, icon, type, boxShadow} = this.props
+    const {message, theme, icon, type, boxShadow, lastAlert} = this.props
     const dark = theme === 'dark'
-    console.log(boxShadow)
     return (
-      <Alert glam={{dark, boxShadow}}>
+      <Alert glam={{dark, boxShadow, lastAlert}}>
         <IconPlaceholder>
           {icon || <Icon glam={{type}} />}
         </IconPlaceholder>

--- a/src/alert/AlertMessage.js
+++ b/src/alert/AlertMessage.js
@@ -49,11 +49,11 @@ class AlertMessage extends Component {
     const dark = theme === 'dark'
     console.log(boxShadow)
     return (
-      <Alert glam={{dark}}>
+      <Alert glam={{dark, boxShadow}}>
         <IconPlaceholder>
           {icon || <Icon glam={{type}} />}
         </IconPlaceholder>
-        <Message glam={{boxShadow}}>
+        <Message>
           {message}
         </Message>
         <Close

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,8 @@
 import AlertContainer from './alert-container'
+import AlertMessage from './alert/AlertMessage'
+
+export {
+  AlertMessage
+}
 
 export default AlertContainer


### PR DESCRIPTION
This pull request adds an onOpen callback feature.  This is a function provided in the options to the instance.show method that (similarly to onClose) calls the provided function after the new alert is added to the state.

I added unit tests to show that the onOpen function does get called when instance.show is called, but only if the option is provided.

This feature is useful in a feature I am building for an order management system application, and I feel it could be useful to others as well.