### PR TITLE
Always get a copy of alerts in withAlert()

### DIFF
--- a/src/withAlert.js
+++ b/src/withAlert.js
@@ -23,11 +23,11 @@ const withAlert = WrappedComponent => {
     }
 
     syncAlerts = alerts => {
-      this.setState({ alerts })
+      this.setState({ alerts: [...alerts] })
     }
 
     componentWillMount () {
-      this.setState({ alerts: this.context.alertContainer._getAlerts() })
+      this.setState({ alerts: [...this.context.alertContainer._getAlerts()] })
     }
 
     componentDidMount () {


### PR DESCRIPTION
Otherwise any withAlert() component that is not the first one will keep the
reference to an out of date list of alerts and show them when its render method
is evetually called. That can be reproduced with the following code:

```
import React, { Component, Fragment } from 'react'
import { withAlert } from 'react-alert'

const Foo = ({alert}) => (<button onClick={() => { alert.info('Foo') }}>Foo</button>);
const FooWithAlert = withAlert(Foo);

const Bar = ({ alert }) => (<button onClick={() => { alert.info('Bar') }}>Bar</button>);
const BarWithAlert = withAlert(Bar);

class Home extends Component {
  state = { now: Date.now() }

  render () {
    return (
      <div>
        <FooWithAlert />
        <BarWithAlert />
        <br />
        <button onClick={() => {this.setState({ now: Date.now() })}}>
          Render wrapping component
        </button>
      </div>
    )
  }
}

export default Home
```