### PR TITLE
withAlert passing other props to the wrapped component

### DIFF
--- a/__tests__/public-api.test.js
+++ b/__tests__/public-api.test.js
@@ -54,6 +54,18 @@ describe('public api', () => {
       expect(child.props.alert.remove).toBeInstanceOf(Function)
     })
 
+    it('should pass other props down to the wrapped component', () => {
+      const ChildWithAlert = withAlert(Child)
+      const tree = TestUtils.renderIntoDocument(
+        <Provider template={AlertTemplate}>
+          <ChildWithAlert customProp={true} />
+        </Provider>
+      )
+
+      const child = TestUtils.findRenderedComponentWithType(tree, Child)
+      expect(child.props.customProp).toBe(true)
+    })
+
     it('should use the given alertTemplate', () => {
       const ChildWithAlert = withAlert(Child)
       const tree = TestUtils.renderIntoDocument(

--- a/src/withAlert.js
+++ b/src/withAlert.js
@@ -13,7 +13,7 @@ const withAlert = WrappedComponent => {
         <Consumer>
           {context => {
             return (
-              <AlertContainer component={WrappedComponent} context={context} />
+              <AlertContainer component={WrappedComponent} context={context} {...this.props} />
             )
           }}
         </Consumer>


### PR DESCRIPTION
Hi,

I ain't sure if it was a design decision, but looks like withAlert doesn't pass to the wrapped component other props besides the ```alert```. This behavior can be checked [here](https://codesandbox.io/s/q930z833mq).

The following PR "fix" this.