### PR TITLE
Abillity to control alert ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ const alert = this.props.alert.error('Some error', {
 // remove
 // use it to remove an alert programmatically
 this.props.alert.remove(alert)
+
+Under the hood, every alerts gets a unique id upon generation. If for some reasons you want to handle the id generation process you can specify the id field in the alert options { id: 'whatever', ... }.
 ```
 
 ## Using a custom alert template

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -42,7 +42,7 @@ class Provider extends Component {
   timerId = []
 
   show = (message = '', options = {}) => {
-    const id = Math.random()
+    const id = options.id || Math.random()
       .toString(36)
       .substr(2, 9)
 
@@ -86,14 +86,23 @@ class Provider extends Component {
 
   remove = alert => {
     this.setState(prevState => {
-      const lengthBeforeRemove = prevState.alerts.length
-      const alerts = prevState.alerts.filter(a => a.id !== alert.id)
-
-      if (lengthBeforeRemove > alerts.length && alert.options.onClose) {
-        alert.options.onClose()
+      const remainingAlerts = []
+      const removedAlerts = [] // in case multiple alerts shares the same id
+      for (let a of prevState.alerts) {
+        if (a.id === alert.id) {
+          removedAlerts.push(a)
+        } else {
+          remainingAlerts.push(a)
+        }
       }
 
-      return { alerts }
+      for (let removedAlert of removedAlerts) {
+        if (removedAlert.options.onClose) {
+           removedAlert.options.onClose()
+        }
+      }
+
+      return { remainingAlerts }
     })
   }
 

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -42,9 +42,11 @@ class Provider extends Component {
   timerId = []
 
   show = (message = '', options = {}) => {
-    const id = options.id || Math.random()
-      .toString(36)
-      .substr(2, 9)
+    const id =
+      options.id ||
+      Math.random()
+        .toString(36)
+        .substr(2, 9)
 
     const { timeout, type } = this.props
 
@@ -98,11 +100,11 @@ class Provider extends Component {
 
       for (let removedAlert of removedAlerts) {
         if (removedAlert.options.onClose) {
-           removedAlert.options.onClose()
+          removedAlert.options.onClose()
         }
       }
 
-      return { remainingAlerts }
+      return { alerts: remainingAlerts }
     })
   }
 


### PR DESCRIPTION
This modifications allow to create alerts with a specific id. Also i slighly changed the remove method to be able to remove an alert with just a mocked object like `remove({id: xxx})`.

This allow to create event triggered alerts (could also be done before this PR), but it's now much more redux compliant, cause you can create alert IDs in redux reducers and pop them up based on the global app state.
