### PR TITLE
Feature: new provider positions

### DIFF
--- a/__tests__/react-alert.spec.js
+++ b/__tests__/react-alert.spec.js
@@ -1,7 +1,7 @@
 import React, { useRef, createContext } from 'react'
 import 'jest-dom/extend-expect'
 import { render, fireEvent, cleanup, act } from 'react-testing-library'
-import { Provider, useAlert, withAlert } from '../src'
+import { positions, Provider, useAlert, withAlert } from '../src'
 import { getStyles } from '../src/Wrapper'
 
 const styleString = style =>
@@ -29,319 +29,303 @@ describe('react-alert', () => {
 
   let Child = () => {
     const alert = useAlert()
-
     return <button onClick={() => alert.show('Message')}>Show Alert</button>
   }
 
   afterEach(cleanup)
 
-  it('should show an alert', () => {
-    const App = props => (
-      <Provider template={Template}>
-        <Child />
-      </Provider>
-    )
+  describe('react-alert with one Provider and minimum needed options', () => {
 
-    const { getByText } = render(<App />)
-    fireEvent.click(getByText(/show alert/i))
+    let tree
+    let getByText, getByTestId, queryAllByText
 
-    expect(getByText(/message/i)).toBeInTheDocument()
-  })
-
-  it('should remove an alert on close click', () => {
-    const App = props => (
-      <Provider template={Template}>
-        <Child />
-      </Provider>
-    )
-
-    const { getByText } = render(<App />)
-    fireEvent.click(getByText(/show alert/i))
-    const alertElement = getByText(/message/i)
-    expect(getByText(/message/i)).toBeInTheDocument()
-
-    fireEvent.click(getByText(/close/i))
-    expect(alertElement).not.toBeInTheDocument()
-  })
-
-  it('should show multiple alerts', () => {
-    const App = props => (
-      <Provider template={Template}>
-        <Child />
-      </Provider>
-    )
-
-    const { getByText, queryAllByText } = render(<App />)
-    fireEvent.click(getByText(/show alert/i))
-    fireEvent.click(getByText(/show alert/i))
-
-    expect(queryAllByText(/message/i)).toHaveLength(2)
-  })
-
-  it('should close an alert automatic after the given timeout', () => {
-    const App = props => (
-      <Provider template={Template} timeout={2000}>
-        <Child />
-      </Provider>
-    )
-
-    const { getByText } = render(<App />)
-    fireEvent.click(getByText(/show alert/i))
-    const alertElement = getByText(/message/i)
-
-    expect(alertElement).toBeInTheDocument()
-    act(() => jest.runAllTimers())
-    expect(alertElement).not.toBeInTheDocument()
-  })
-
-  it('should be able to show an alert calling success', () => {
-    Child = () => {
-      const alert = useAlert()
-
-      return (
-        <button onClick={() => alert.success('Message')}>Show Alert</button>
+    let renderApp = () => {
+      const App = () => (
+        <Provider template={Template}>
+          <Child/>
+        </Provider>
       )
+      return render(<App/>)
     }
 
-    const App = props => (
-      <Provider template={Template}>
-        <Child />
-      </Provider>
-    )
+    beforeEach(() => {
+      tree = renderApp()
+      getByText = tree.getByText
+      getByTestId = tree.getByTestId
+      queryAllByText = tree.queryAllByText
+    })
 
-    const { getByText } = render(<App />)
-    fireEvent.click(getByText(/show alert/i))
-    expect(getByText(/type: success/i)).toBeInTheDocument()
+    it('should show an alert', () => {
+      fireEvent.click(getByText(/show alert/i))
+      expect(getByText(/message/i)).toBeInTheDocument()
+    })
+
+    it('should remove an alert on close click', () => {
+      fireEvent.click(getByText(/show alert/i))
+      const alertElement = getByText(/message/i)
+      expect(getByText(/message/i)).toBeInTheDocument()
+
+      fireEvent.click(getByText(/close/i))
+      expect(alertElement).not.toBeInTheDocument()
+    })
+
+    it('should show multiple alerts', () => {
+      fireEvent.click(getByText(/show alert/i))
+      fireEvent.click(getByText(/show alert/i))
+
+      expect(queryAllByText(/message/i)).toHaveLength(2)
+    })
+
   })
 
-  it('should be able to show an alert calling error', () => {
-    Child = () => {
-      const alert = useAlert()
+  describe('react-alert with one Provider and different types of alerts', () => {
 
-      return <button onClick={() => alert.error('Message')}>Show Alert</button>
-    }
-
-    const App = props => (
-      <Provider template={Template}>
-        <Child />
-      </Provider>
-    )
-
-    const { getByText } = render(<App />)
-    fireEvent.click(getByText(/show alert/i))
-    expect(getByText(/type: error/i)).toBeInTheDocument()
-  })
-
-  it('should be able to show an alert calling info', () => {
-    Child = () => {
-      const alert = useAlert()
-
-      return <button onClick={() => alert.info('Message')}>Show Alert</button>
-    }
-
-    const App = props => (
-      <Provider template={Template}>
-        <Child />
-      </Provider>
-    )
-
-    const { getByText } = render(<App />)
-    fireEvent.click(getByText(/show alert/i))
-    expect(getByText(/type: info/i)).toBeInTheDocument()
-  })
-
-  it('should call onOpen and onClose callbacks', () => {
-    const onOpen = jest.fn()
-    const onClose = jest.fn()
-
-    Child = () => {
-      const alert = useAlert()
-
-      return (
-        <button onClick={() => alert.info('Message', { onOpen, onClose })}>
-          Show Alert
-        </button>
+    let renderApp = (CustomChild) => {
+      const App = () => (
+        <Provider template={Template}>
+          <CustomChild/>
+        </Provider>
       )
+      return render(<App/>)
     }
 
-    const App = props => (
-      <Provider template={Template}>
-        <Child />
-      </Provider>
-    )
+    it('should be able to show an alert calling success', () => {
+      let SuccessChild = () => {
+        const alert = useAlert()
+        return <button onClick={() => alert.success('Message')}>Show Alert</button>
+      }
+      const { getByText } = renderApp(SuccessChild);
 
-    const { getByText } = render(<App />)
-    fireEvent.click(getByText(/show alert/i))
-    expect(onOpen).toHaveBeenCalledTimes(1)
+      fireEvent.click(getByText(/show alert/i))
+      expect(getByText(/type: success/i)).toBeInTheDocument()
+    })
 
-    fireEvent.click(getByText(/close/i))
-    expect(onClose).toHaveBeenCalledTimes(1)
+    it('should be able to show an alert calling error', () => {
+      let ErrorChild = () => {
+        const alert = useAlert()
+        return <button onClick={() => alert.error('Message')}>Show Alert</button>
+      }
+
+      const { getByText } = renderApp(ErrorChild);
+
+      fireEvent.click(getByText(/show alert/i))
+      expect(getByText(/type: error/i)).toBeInTheDocument()
+    })
+
+    it('should be able to show an alert calling info', () => {
+      let InfoChild = () => {
+        const alert = useAlert()
+        return <button onClick={() => alert.info('Message')}>Show Alert</button>
+      }
+
+      const { getByText } = renderApp(InfoChild);
+
+      fireEvent.click(getByText(/show alert/i))
+      expect(getByText(/type: info/i)).toBeInTheDocument()
+    })
+
+    it('should call onOpen and onClose callbacks', () => {
+      const onOpen = jest.fn()
+      const onClose = jest.fn()
+
+      let InfoChild = () => {
+        const alert = useAlert()
+
+        return (
+          <button onClick={() => alert.info('Message', { onOpen, onClose })}>
+            Show Alert
+          </button>
+        )
+      }
+
+      const { getByText } = renderApp(InfoChild);
+
+      fireEvent.click(getByText(/show alert/i))
+      expect(onOpen).toHaveBeenCalledTimes(1)
+
+      fireEvent.click(getByText(/close/i))
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
   })
 
-  it('should accept different position options', () => {
-    const positions = [
-      'top left',
-      'top right',
-      'bottom left',
-      'bottom right',
-      'top center',
-      'bottom center'
-    ]
+  describe('react-alert with one Provider and custom options', () => {
 
-    positions.forEach(position => {
+    it('should close an alert automatic after the given timeout', () => {
+      const App = () => (
+        <Provider template={Template} timeout={2000}>
+          <Child/>
+        </Provider>
+      )
+      const { getByText } = render(<App/>)
+
+      fireEvent.click(getByText(/show alert/i))
+      const alertElement = getByText(/message/i)
+
+      expect(alertElement).toBeInTheDocument()
+      act(() => jest.runAllTimers())
+      expect(alertElement).not.toBeInTheDocument()
+    })
+
+    it('should accept different position options', () => {
+
+      Object.values(positions).forEach(position => {
+        const App = props => (
+          <Provider
+            data-testid="provider"
+            template={Template}
+            position={position}
+          >
+            <Child/>
+          </Provider>
+        )
+
+        const { getByText, getByTestId } = render(<App/>)
+        fireEvent.click(getByText(/show alert/i))
+
+        const providerElement = getByTestId('provider')
+        const styles = styleString(getStyles(position))
+        expect(providerElement).toHaveStyle(styles)
+        cleanup()
+      })
+    })
+
+    it('should accept a containerStyle option', () => {
+      const containerStyle = { zIndex: 50, border: '1px solid red' }
       const App = props => (
         <Provider
           data-testid="provider"
           template={Template}
-          position={position}
+          containerStyle={containerStyle}
         >
-          <Child />
+          <Child/>
         </Provider>
       )
 
-      const { getByText, getByTestId } = render(<App />)
+      const { getByText, getByTestId } = render(<App/>)
       fireEvent.click(getByText(/show alert/i))
 
       const providerElement = getByTestId('provider')
-      const styles = styleString(getStyles(position))
+      const styles = styleString(containerStyle)
       expect(providerElement).toHaveStyle(styles)
-      cleanup()
-    })
-  })
-
-  it('should accept a containerStyle option', () => {
-    const containerStyle = { zIndex: 50, border: '1px solid red' }
-    const App = props => (
-      <Provider
-        data-testid="provider"
-        template={Template}
-        containerStyle={containerStyle}
-      >
-        <Child />
-      </Provider>
-    )
-
-    const { getByText, getByTestId } = render(<App />)
-    fireEvent.click(getByText(/show alert/i))
-
-    const providerElement = getByTestId('provider')
-    const styles = styleString(containerStyle)
-    expect(providerElement).toHaveStyle(styles)
-  })
-
-  it('should respect the given offset option', () => {
-    const App = props => (
-      <Provider template={Template} offset="30px">
-        <Child />
-      </Provider>
-    )
-
-    const { getByText, getByTestId } = render(<App />)
-    fireEvent.click(getByText(/show alert/i))
-    const alertElement = getByTestId('alert')
-    expect(alertElement).toHaveStyle('margin: 30px')
-  })
-
-  it('should remove the alert matching the given id on remove call', () => {
-    Child = () => {
-      const alert = useAlert()
-      const alertRef = useRef(null)
-
-      return (
-        <div>
-          <button
-            onClick={() => {
-              alertRef.current = alert.show('Message')
-            }}
-          >
-            Show Alert
-          </button>
-          <button
-            onClick={() => {
-              if (alertRef.current) alert.remove(alertRef.current)
-            }}
-          >
-            Remove Alert
-          </button>
-        </div>
-      )
-    }
-
-    const App = props => (
-      <Provider template={Template}>
-        <Child />
-      </Provider>
-    )
-
-    const { getByText, getByTestId } = render(<App />)
-    fireEvent.click(getByText(/show alert/i))
-    const alertElement = getByText(/message/i)
-    expect(getByText(/message/i)).toBeInTheDocument()
-
-    fireEvent.click(getByText(/remove alert/i))
-    expect(alertElement).not.toBeInTheDocument()
-  })
-
-  it('should work with withAlert HOC', () => {
-    Child = withAlert()(({ alert }) => {
-      return <button onClick={() => alert.show('Message')}>Show Alert</button>
     })
 
-    const App = props => (
-      <Provider template={Template}>
-        <Child />
-      </Provider>
-    )
-
-    const { getByText } = render(<App />)
-    fireEvent.click(getByText(/show alert/i))
-
-    expect(getByText(/message/i)).toBeInTheDocument()
-  })
-
-  it('should accept a context option', () => {
-    const BottomLeftAlertContext = createContext()
-
-    Child = () => {
-      const alert = useAlert()
-      const bottomLeftAlert = useAlert(BottomLeftAlertContext)
-
-      return (
-        <div>
-          <button
-            data-testid="default-context"
-            onClick={() => alert.show('Message')}
-          >
-            Show Alert
-          </button>
-          <button
-            data-testid="custom-context"
-            onClick={() => bottomLeftAlert.show('Bottom Left Message')}
-          >
-            Show Bottom Left Alert
-          </button>
-        </div>
-      )
-    }
-
-    const App = props => (
-      <Provider template={Template}>
-        <Provider
-          template={Template}
-          context={BottomLeftAlertContext}
-          position="bottom left"
-        >
-          <Child />
+    it('should respect the given offset option', () => {
+      const App = props => (
+        <Provider template={Template} offset="30px">
+          <Child/>
         </Provider>
-      </Provider>
-    )
+      )
 
-    const { getByText, getByTestId } = render(<App />)
+      const { getByText, getByTestId } = render(<App/>)
+      fireEvent.click(getByText(/show alert/i))
+      const alertElement = getByTestId('alert')
+      expect(alertElement).toHaveStyle('margin: 30px')
+    })
 
-    fireEvent.click(getByTestId('default-context'))
-    expect(getByText(/message/i)).toBeInTheDocument()
+    it('should remove the alert matching the given id on remove call', () => {
+      Child = () => {
+        const alert = useAlert()
+        const alertRef = useRef(null)
 
-    fireEvent.click(getByTestId('custom-context'))
-    expect(getByText(/bottom left message/i)).toBeInTheDocument()
+        return (
+          <div>
+            <button
+              onClick={() => {
+                alertRef.current = alert.show('Message')
+              }}
+            >
+              Show Alert
+            </button>
+            <button
+              onClick={() => {
+                if (alertRef.current) alert.remove(alertRef.current)
+              }}
+            >
+              Remove Alert
+            </button>
+          </div>
+        )
+      }
+
+      const App = props => (
+        <Provider template={Template}>
+          <Child/>
+        </Provider>
+      )
+
+      const { getByText } = render(<App/>)
+      fireEvent.click(getByText(/show alert/i))
+      const alertElement = getByText(/message/i)
+      expect(getByText(/message/i)).toBeInTheDocument()
+
+      fireEvent.click(getByText(/remove alert/i))
+      expect(alertElement).not.toBeInTheDocument()
+    })
+
+    it('should work with withAlert HOC', () => {
+      Child = withAlert()(({ alert }) => {
+        return <button onClick={() => alert.show('Message')}>Show Alert</button>
+      })
+
+      const App = props => (
+        <Provider template={Template}>
+          <Child/>
+        </Provider>
+      )
+
+      const { getByText } = render(<App/>)
+      fireEvent.click(getByText(/show alert/i))
+
+      expect(getByText(/message/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('react-alert with multiple Providers', () => {
+
+    it('should accept a context option', () => {
+      const BottomLeftAlertContext = createContext()
+
+      let ComplexChild = () => {
+        const alert = useAlert()
+        const bottomLeftAlert = useAlert(BottomLeftAlertContext)
+
+        return (
+          <div>
+            <button
+              data-testid="default-context"
+              onClick={() => alert.show('Message')}
+            >
+              Show Alert
+            </button>
+            <button
+              data-testid="custom-context"
+              onClick={() => bottomLeftAlert.show('Bottom Left Message')}
+            >
+              Show Bottom Left Alert
+            </button>
+          </div>
+        )
+      }
+
+      const App = props => (
+        <Provider template={Template}>
+          <Provider
+            template={Template}
+            context={BottomLeftAlertContext}
+            position="bottom left"
+          >
+            <ComplexChild/>
+          </Provider>
+        </Provider>
+      )
+
+      const { getByText, getByTestId } = render(<App/>)
+
+      fireEvent.click(getByTestId('default-context'))
+      expect(getByText(/message/i)).toBeInTheDocument()
+
+      fireEvent.click(getByTestId('custom-context'))
+      expect(getByText(/bottom left message/i)).toBeInTheDocument()
+    })
   })
 })

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom'
 import DefaultContext from './Context'
 import Wrapper from './Wrapper'
 import Transition from './Transition'
+import { positions, transitions, types } from './options'
 
 const Provider = ({
   children,
@@ -82,17 +83,17 @@ const Provider = ({
   }
 
   const success = (message = '', options = {}) => {
-    options.type = 'success'
+    options.type = types.SUCCESS
     return show(message, options)
   }
 
   const error = (message = '', options = {}) => {
-    options.type = 'error'
+    options.type = types.ERROR
     return show(message, options)
   }
 
   const info = (message = '', options = {}) => {
-    options.type = 'info'
+    options.type = types.INFO
     return show(message, options)
   }
 
@@ -128,20 +129,10 @@ const Provider = ({
 
 Provider.propTypes = {
   offset: PropTypes.string,
-  position: PropTypes.oneOf([
-    'top left',
-    'top right',
-    'top center',
-    'middle left',
-    'middle right',
-    'middle',
-    'bottom left',
-    'bottom right',
-    'bottom center'
-  ]),
+  position: PropTypes.oneOf(Object.values(positions)),
   timeout: PropTypes.number,
-  type: PropTypes.oneOf(['info', 'success', 'error']),
-  transition: PropTypes.oneOf(['fade', 'scale']),
+  type: PropTypes.oneOf(Object.values(types)),
+  transition: PropTypes.oneOf(Object.values(transitions)),
   containerStyle: PropTypes.object,
   template: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
   context: PropTypes.shape({
@@ -152,10 +143,10 @@ Provider.propTypes = {
 
 Provider.defaultProps = {
   offset: '10px',
-  position: 'top center',
+  position: positions.TOP_CENTER,
   timeout: 0,
-  type: 'info',
-  transition: 'fade',
+  type: types.INFO,
+  transition: transitions.FADE,
   containerStyle: {
     zIndex: 100
   },

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -132,6 +132,9 @@ Provider.propTypes = {
     'top left',
     'top right',
     'top center',
+    'middle left',
+    'middle right',
+    'middle',
     'bottom left',
     'bottom right',
     'bottom center'

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -1,25 +1,26 @@
 import React from 'react'
 import { Transition as AlertTransition } from 'react-transition-group'
+import { transitions } from './options'
 
 const duration = 250
 
 const defaultStyle = {
-  fade: {
+  [transitions.FADE]: {
     transition: `opacity ${duration}ms ease`,
     opacity: 0
   },
-  scale: {
+  [transitions.SCALE]: {
     transform: 'scale(1)',
     transition: `all ${duration}ms ease-in-out`
   }
 }
 
 const transitionStyles = {
-  fade: {
+  [transitions.FADE]: {
     entering: { opacity: 0 },
     entered: { opacity: 1 }
   },
-  scale: {
+  [transitions.SCALE]: {
     entering: { transform: 'scale(0)' },
     entered: { transform: 'scale(1)' },
     exiting: { transform: 'scale(0)' },

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -1,40 +1,35 @@
 import React, { useMemo } from 'react'
+import { positions } from './options'
 
 export const getStyles = position => {
   const initialStyles = { position: 'fixed' }
   switch (position) {
-    case 'top left':
+    case positions.TOP_LEFT:
       return {
         top: 0,
         left: 0,
         ...initialStyles
       }
-    case 'top right':
-      return {
-        top: 0,
-        right: 0,
-        ...initialStyles
-      }
-    case 'top center':
+    case positions.TOP_CENTER:
       return {
         top: 0,
         left: '50%',
         transform: 'translate(-50%, 0%)',
         ...initialStyles
       }
-    case 'middle left':
+    case positions.TOP_RIGHT:
+      return {
+        top: 0,
+        right: 0,
+        ...initialStyles
+      }
+    case positions.MIDDLE_LEFT:
       return {
         bottom: '50%',
         left: 0,
         ...initialStyles
       }
-    case 'middle right':
-      return {
-        bottom: '50%',
-        right: 0,
-        ...initialStyles
-      }
-    case 'middle': {
+    case positions.MIDDLE: {
       return {
         bottom: '50%',
         left: '50%',
@@ -42,23 +37,30 @@ export const getStyles = position => {
         ...initialStyles
       }
     }
-    case 'bottom left':
+    case positions.MIDDLE_RIGHT:
+      return {
+        bottom: '50%',
+        right: 0,
+        ...initialStyles
+      }
+
+    case positions.BOTTOM_LEFT:
       return {
         bottom: 0,
         left: 0,
         ...initialStyles
       }
-    case 'bottom right':
-      return {
-        right: 0,
-        bottom: 0,
-        ...initialStyles
-      }
-    case 'bottom center':
+    case positions.BOTTOM_CENTER:
       return {
         bottom: 0,
         left: '50%',
         transform: 'translate(-50%, 0%)',
+        ...initialStyles
+      }
+    case positions.BOTTOM_RIGHT:
+      return {
+        right: 0,
+        bottom: 0,
         ...initialStyles
       }
   }

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -1,56 +1,65 @@
 import React, { useMemo } from 'react'
 
 export const getStyles = position => {
+  const initialStyles = { position: 'fixed' }
   switch (position) {
     case 'top left':
       return {
-        position: 'fixed',
         top: 0,
-        right: 'auto',
-        bottom: 'auto',
-        left: 0
+        left: 0,
+        ...initialStyles
       }
     case 'top right':
       return {
-        position: 'fixed',
         top: 0,
         right: 0,
-        bottom: 'auto',
-        left: 'auto'
-      }
-    case 'bottom left':
-      return {
-        position: 'fixed',
-        top: 'auto',
-        right: 'auto',
-        bottom: 0,
-        left: 0
-      }
-    case 'bottom right':
-      return {
-        position: 'fixed',
-        top: 'auto',
-        right: 0,
-        bottom: 0,
-        left: 'auto'
+        ...initialStyles
       }
     case 'top center':
       return {
-        position: 'fixed',
         top: 0,
-        right: 'auto',
-        bottom: 'auto',
         left: '50%',
-        transform: 'translate(-50%, 0%)'
+        transform: 'translate(-50%, 0%)',
+        ...initialStyles
+      }
+    case 'middle left':
+      return {
+        bottom: '50%',
+        left: 0,
+        ...initialStyles
+      }
+    case 'middle right':
+      return {
+        bottom: '50%',
+        right: 0,
+        ...initialStyles
+      }
+    case 'middle': {
+      return {
+        bottom: '50%',
+        left: '50%',
+        transform: 'translate(-50%, 0%)',
+        ...initialStyles
+      }
+    }
+    case 'bottom left':
+      return {
+        bottom: 0,
+        left: 0,
+        ...initialStyles
+      }
+    case 'bottom right':
+      return {
+        right: 0,
+        bottom: 0,
+        ...initialStyles
       }
     case 'bottom center':
       return {
-        position: 'fixed',
-        top: 'auto',
-        right: 'auto',
         bottom: 0,
         left: '50%',
-        transform: 'translate(-50%, 0%)'
+        transform: 'translate(-50%, 0%)',
+        ...initialStyles
       }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import Provider from './Provider'
 import useAlert from './useAlert'
 import withAlert from './withAlert'
+import { positions, types, transitions } from './options'
 
-export { Provider, useAlert, withAlert }
+export { Provider, useAlert, withAlert, positions, types, transitions }

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,22 @@
+export const positions = {
+  TOP_LEFT: 'top left',
+  TOP_CENTER: 'top center',
+  TOP_RIGHT: 'top right',
+  MIDDLE_LEFT: 'middle left',
+  MIDDLE: 'middle',
+  MIDDLE_RIGHT: 'middle right',
+  BOTTOM_LEFT: 'bottom left',
+  BOTTOM_CENTER: 'bottom center',
+  BOTTOM_RIGHT: 'bottom right'
+}
+
+export const types = {
+  INFO: 'info',
+  SUCCESS: 'success',
+  ERROR: 'error'
+}
+
+export const transitions = {
+  FADE: 'fade',
+  SCALE: 'scale'
+}


### PR DESCRIPTION
Hi Reinaldo!
I added the possibility to render alerts in additional positions:
- 'middle left', 
- 'middle',
-  'middle right'. 

I also added exported constants in `options.js` file which gives the opportunity not to type strings with positions, transitions, and types of alert.  Moreover, a little bit restructure the test suites.

Waiting for the feedback:)
