### PR TITLE
Fix for direct alert position property

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,14 +143,45 @@ containerStyle: PropTypes.Object // style to be applied in the alerts container
 template: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired // the alert template to be used
 ```
 
+Note that the position, type and transition strings are available as constants which can be imported the next way: 
+```js
+import { positions, transitions, types } from 'react-alert'
+```
+
+and have such values: 
+```js
+export const positions = {
+  TOP_LEFT: 'top left',
+  TOP_CENTER: 'top center',
+  TOP_RIGHT: 'top right',
+  MIDDLE_LEFT: 'middle left',
+  MIDDLE: 'middle',
+  MIDDLE_RIGHT: 'middle right',
+  BOTTOM_LEFT: 'bottom left',
+  BOTTOM_CENTER: 'bottom center',
+  BOTTOM_RIGHT: 'bottom right'
+}
+
+export const types = {
+  INFO: 'info',
+  SUCCESS: 'success',
+  ERROR: 'error'
+}
+
+export const transitions = {
+  FADE: 'fade',
+  SCALE: 'scale'
+}
+```
+
 Here's the defaults:
 
 ```js
 offset: '10px'
-position: 'top center'
+position: positions.TOP_CENTER
 timeout: 0
-type: 'info'
-transition: 'fade',
+type: types.INFO
+transition: transitions.FADE,
 containerStyle: {
   zIndex: 100
 }
@@ -259,9 +290,13 @@ You can also pass in a component as a message, like this:
 alert.show(<div style={{ color: 'blue' }}>Some Message</div>)
 ```
 
-## Using multiple Providers
+## Showing alerts in different positions at the same time
 
-You can use different Contexts to show alerts in different style and position:
+First of all, if have a need to separate the logic of showing alerts in different
+positions at the same time it is possible to use multiple AlertProviders in one project and 
+nest them across the DOM tree. Also you can use different Contexts to get the references
+to each type of alert separately. 
+
 
 ```js
 import React, { createContext } from 'react'
@@ -301,6 +336,64 @@ const Root = () => (
       <App />
     </AlertProvider>
   </AlertProvider>
+)
+
+render(<Root />, document.getElementById('root'))
+```
+
+Another use case is when you don't want to nest a couple of AlertProviders
+because it will somehow complicate management of alerts (for example when you 
+need to show alerts in more than three different positions). 
+
+In this case you can pass the position directly to the alert. The alerts without
+individual position property will take it from the Provider. 
+Instead, passing the position to methods `show`, `success`, `info`, `error` will 
+overlap the Provider's position.
+
+Passing the property `position` will look like this: 
+```js
+alert.show('Oh look, an alert!', {position: positions.BOTTOM_LEFT})
+```
+
+An example of showing alerts simultaneously in three different positions: 
+```js
+import React from 'react';
+import { render } from 'react-dom'
+import { Provider as AlertProvider, useAlert, positions, transitions } from 'react-alert';
+import AlertTemplate from 'react-alert-template-basic'
+
+const alertOptions = {
+    offset: '25px',
+    timeout: 3000,
+    transition: transitions.SCALE
+};
+
+const App = () => {
+    const alert = useAlert()
+
+    const showAlert = () => {
+            alert.show('Oh look, an alert!', {position: positions.BOTTOM_LEFT}) //alert will be shown in bottom left
+            alert.show('Oh look, an alert!', {position: positions.BOTTOM_RIGHT}) //alert will be shown in bottom right
+            alert.show('Oh look, an alert!') //alert will use the Provider's position `top right`
+    }
+
+    return (
+        <button onClick={showAlert}>
+            Show Alert
+        </button>
+    )
+}
+
+const Root = () => (
+    <AlertProvider template={AlertTemplate}>
+        <AlertProvider
+            template={AlertTemplate}
+            position={positions.TOP_RIGHT} //default position for all alerts without individual position
+            {...alertOptions}
+        >
+            <App />
+        </AlertProvider>
+    </AlertProvider>
 )
 
 render(<Root />, document.getElementById('root'))

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ containerStyle: {
 }
 ```
 
-Those options will be applied to all alerts.
+Those options will be applied to all alerts (please, also have a look at [edge-cases](#showing-alerts-in-different-positions-at-the-same-time))
 
 ## Api
 

--- a/__tests__/react-alert.spec.js
+++ b/__tests__/react-alert.spec.js
@@ -12,8 +12,11 @@ const styleString = style =>
 jest.useFakeTimers()
 
 jest.mock('react-transition-group', () => {
+  const mockStyles = require('../src/Wrapper').getStyles;
   const FakeTransition = ({ children }) => children('entered')
-  const FakeTransitionGroup = ({ children }) => children
+  const FakeWrapper = ({ children, options: { position, containerStyle }, ...props }) =>
+    <div style={{ ...mockStyles(position), ...containerStyle }} {...props}>{children}</div>
+  const FakeTransitionGroup = ({ children, appear, component, ...props }) => <FakeWrapper {...props}>{children}</FakeWrapper>
 
   return { TransitionGroup: FakeTransitionGroup, Transition: FakeTransition }
 })
@@ -94,7 +97,7 @@ describe('react-alert', () => {
         const alert = useAlert()
         return <button onClick={() => alert.success('Message')}>Show Alert</button>
       }
-      const { getByText } = renderApp(SuccessChild);
+      const { getByText } = renderApp(SuccessChild)
 
       fireEvent.click(getByText(/show alert/i))
       expect(getByText(/type: success/i)).toBeInTheDocument()
@@ -106,7 +109,7 @@ describe('react-alert', () => {
         return <button onClick={() => alert.error('Message')}>Show Alert</button>
       }
 
-      const { getByText } = renderApp(ErrorChild);
+      const { getByText } = renderApp(ErrorChild)
 
       fireEvent.click(getByText(/show alert/i))
       expect(getByText(/type: error/i)).toBeInTheDocument()
@@ -118,7 +121,7 @@ describe('react-alert', () => {
         return <button onClick={() => alert.info('Message')}>Show Alert</button>
       }
 
-      const { getByText } = renderApp(InfoChild);
+      const { getByText } = renderApp(InfoChild)
 
       fireEvent.click(getByText(/show alert/i))
       expect(getByText(/type: info/i)).toBeInTheDocument()
@@ -138,7 +141,7 @@ describe('react-alert', () => {
         )
       }
 
-      const { getByText } = renderApp(InfoChild);
+      const { getByText } = renderApp(InfoChild)
 
       fireEvent.click(getByText(/show alert/i))
       expect(onOpen).toHaveBeenCalledTimes(1)
@@ -250,7 +253,7 @@ describe('react-alert', () => {
     })
 
     it('should render multiple wrappers relying on amount of positions giving to alerts', () => {
-      const parentPosition = positions.TOP_CENTER;
+      const parentPosition = positions.TOP_CENTER
       Child = () => {
         const alert = useAlert()
         return (

--- a/__tests__/react-alert.spec.js
+++ b/__tests__/react-alert.spec.js
@@ -4,7 +4,7 @@ import { render, fireEvent, cleanup, act, wait } from 'react-testing-library'
 import { positions, Provider, useAlert, withAlert } from '../src'
 import { getStyles } from '../src/Wrapper'
 
-jest.useFakeTimers();
+jest.useFakeTimers()
 
 const styleString = style =>
   Object.entries(style).reduce((styleString, [propName, propValue]) => {
@@ -156,12 +156,12 @@ describe('react-alert', () => {
       fireEvent.click(getByText(/show alert/i))
       const alertElement = getByText(/message/i)
 
-      expect(alertElement).toBeInTheDocument();
+      expect(alertElement).toBeInTheDocument()
 
-      act(jest.runAllTimers)
-      act(jest.runOnlyPendingTimers)
-
-      expect(alertElement).not.toBeInTheDocument()
+      wait(() => {
+        act(jest.runOnlyPendingTimers)
+        expect(alertElement).not.toBeInTheDocument()
+      })
     })
 
     it('should accept different position options', () => {
@@ -330,7 +330,7 @@ describe('react-alert', () => {
       expect(getByText(/message/i)).toBeInTheDocument()
 
       fireEvent.click(getByText(/remove alert/i))
-      act(jest.runOnlyPendingTimers);
+      act(jest.runOnlyPendingTimers)
 
       expect(alertElement).not.toBeInTheDocument()
     })

--- a/__tests__/react-alert.spec.js
+++ b/__tests__/react-alert.spec.js
@@ -4,22 +4,12 @@ import { render, fireEvent, cleanup, act, waitForElement } from 'react-testing-l
 import { positions, Provider, useAlert, withAlert } from '../src'
 import { getStyles } from '../src/Wrapper'
 
+const transitionTime = 250;
+
 const styleString = style =>
   Object.entries(style).reduce((styleString, [propName, propValue]) => {
     return `${styleString}${propName}:${propValue};`
   }, '')
-
-jest.useFakeTimers()
-
-jest.mock('react-transition-group', () => {
-  const mockStyles = require('../src/Wrapper').getStyles;
-  const FakeTransition = ({ children }) => children('entered')
-  const FakeWrapper = ({ children, options: { position, containerStyle }, ...props }) =>
-    <div style={{ ...mockStyles(position), ...containerStyle }} {...props}>{children}</div>
-  const FakeTransitionGroup = ({ children, appear, component, ...props }) => <FakeWrapper {...props}>{children}</FakeWrapper>
-
-  return { TransitionGroup: FakeTransitionGroup, Transition: FakeTransition }
-})
 
 describe('react-alert', () => {
   const Template = ({ message, close, options: { type }, style }) => (
@@ -44,7 +34,7 @@ describe('react-alert', () => {
 
     let renderApp = () => {
       const App = () => (
-        <Provider template={Template}>
+        <Provider template={Template} data-testid="provider">
           <Child/>
         </Provider>
       )
@@ -69,7 +59,10 @@ describe('react-alert', () => {
       expect(getByText(/message/i)).toBeInTheDocument()
 
       fireEvent.click(getByText(/close/i))
-      expect(alertElement).not.toBeInTheDocument()
+
+      setTimeout(()=> {
+        expect(alertElement).not.toBeInTheDocument()
+      },transitionTime)
     })
 
     it('should show multiple alerts', () => {
@@ -154,8 +147,9 @@ describe('react-alert', () => {
   describe('react-alert with one Provider and custom options', () => {
 
     it('should close an alert automatic after the given timeout', () => {
+      const timeout = 2000;
       const App = () => (
-        <Provider template={Template} timeout={2000}>
+        <Provider template={Template} timeout={timeout}>
           <Child/>
         </Provider>
       )
@@ -164,9 +158,11 @@ describe('react-alert', () => {
       fireEvent.click(getByText(/show alert/i))
       const alertElement = getByText(/message/i)
 
-      expect(alertElement).toBeInTheDocument()
-      act(() => jest.runAllTimers())
-      expect(alertElement).not.toBeInTheDocument()
+      expect(alertElement).toBeInTheDocument();
+
+      setTimeout(()=> {
+        expect(alertElement).not.toBeInTheDocument()
+      },timeout)
     })
 
     it('should accept different position options', () => {
@@ -186,6 +182,7 @@ describe('react-alert', () => {
         fireEvent.click(getByText(/show alert/i))
 
         const providerElement = getByTestId('provider')
+
         const styles = styleString(getStyles(position))
         expect(providerElement).toHaveStyle(styles)
         cleanup()
@@ -340,7 +337,10 @@ describe('react-alert', () => {
       expect(getByText(/message/i)).toBeInTheDocument()
 
       fireEvent.click(getByText(/remove alert/i))
-      expect(alertElement).not.toBeInTheDocument()
+
+      setTimeout(()=> {
+        expect(alertElement).not.toBeInTheDocument()
+      },transitionTime)
     })
 
     it('should work with withAlert HOC', () => {

--- a/__tests__/react-alert.spec.js
+++ b/__tests__/react-alert.spec.js
@@ -34,7 +34,7 @@ describe('react-alert', () => {
 
     let renderApp = () => {
       const App = () => (
-        <Provider template={Template} data-testid="provider">
+        <Provider template={Template}>
           <Child/>
         </Provider>
       )

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -6,6 +6,7 @@ import DefaultContext from './Context'
 import Wrapper from './Wrapper'
 import Transition from './Transition'
 import { positions, transitions, types } from './options'
+import { groupBy } from './helpers'
 
 const Provider = ({
   children,
@@ -53,6 +54,7 @@ const Provider = ({
       .substr(2, 9)
 
     const alertOptions = {
+      position: options.position || position,
       timeout,
       type,
       ...options
@@ -107,20 +109,30 @@ const Provider = ({
     info
   }
 
+  const alertsByPosition = groupBy(alerts, alert => alert.options.position)
+
   return (
     <Context.Provider value={alertContext}>
       {children}
       {root.current &&
         createPortal(
-          <Wrapper options={{ position, containerStyle }} {...props}>
-            <TransitionGroup>
-              {alerts.map(alert => (
-                <Transition type={transition} key={alert.id} appear={true}>
-                  <AlertComponent style={{ margin: offset }} {...alert} />
-                </Transition>
-              ))}
-            </TransitionGroup>
-          </Wrapper>,
+          <>
+            {Object.keys(alertsByPosition).map(position => (
+              <Wrapper
+                options={{ position, containerStyle }}
+                key={position}
+                {...props}
+              >
+                <TransitionGroup>
+                  {alertsByPosition[position].map(alert => (
+                    <Transition type={transition} key={alert.id} appear={true}>
+                      <AlertComponent style={{ margin: offset }} {...alert} />
+                    </Transition>
+                  ))}
+                </TransitionGroup>
+              </Wrapper>
+            ))}
+          </>,
           root.current
         )}
     </Context.Provider>

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -122,8 +122,8 @@ const Provider = ({
                 appear
                 key={position}
                 options={{ position, containerStyle }}
-                {...props}
                 component={Wrapper}
+                {...props}
               >
                 {alertsByPosition[position]
                   ? alertsByPosition[position].map(alert => (

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -117,20 +117,22 @@ const Provider = ({
       {root.current &&
         createPortal(
           <>
-            {Object.keys(alertsByPosition).map(position => (
-              <Wrapper
-                options={{ position, containerStyle }}
+            {Object.values(positions).map(position => (
+              <TransitionGroup
+                appear
                 key={position}
+                options={{ position, containerStyle }}
                 {...props}
+                component={Wrapper}
               >
-                <TransitionGroup>
-                  {alertsByPosition[position].map(alert => (
-                    <Transition type={transition} key={alert.id} appear={true}>
-                      <AlertComponent style={{ margin: offset }} {...alert} />
-                    </Transition>
-                  ))}
-                </TransitionGroup>
-              </Wrapper>
+                {alertsByPosition[position]
+                  ? alertsByPosition[position].map(alert => (
+                      <Transition type={transition} key={alert.id}>
+                        <AlertComponent style={{ margin: offset }} {...alert} />
+                      </Transition>
+                    ))
+                  : null}
+              </TransitionGroup>
             ))}
           </>,
           root.current

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -74,9 +74,11 @@ const Wrapper = ({
   const styles = useMemo(() => getStyles(position), [position])
 
   return (
-    <div style={{ ...styles, ...containerStyle }} {...props}>
-      {children}
-    </div>
+    children.length > 0 && (
+      <div style={{ ...styles, ...containerStyle }} {...props}>
+        {children}
+      </div>
+    )
   )
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,7 @@
+export const groupBy = (array, fn) =>
+  array.reduce((result, item) => {
+    const key = fn(item)
+    if (!result[key]) result[key] = []
+    result[key].push(item)
+    return result
+  }, {})


### PR DESCRIPTION
Hi Reinaldo!
I have finally found an issue for resolving the bugs which I created:)

So, the main point is that I tried to add the node `Wrapper` between `TransitionGroup` and `Transition` and that was my main fault, despite the fact, that I redirected `props` to the needed elements. For such case,` the `TransitionGroup` have property `component` and I refactored it the next way:
```
<TransitionGroup
     appear
     key={position}
     options={{ position, containerStyle }}
     component={Wrapper}
     {...props}
>
{...}
</TransitionGroup>
```

If we'll look at the source code of the [react-transition-group](https://github.com/reactjs/react-transition-group) we will see, that all extra-properties are redirected to component, that's why I added property `options` to the `TransitionGroup` itself:

**TransitionGroup.js**
```
render() {
    const { component: Component, childFactory, ...props } = this.props
    {....}

    if (Component === null) {
      return children
    }
    return <Component {...props}>{children}</Component>
  }
}
```

I also found out, that animation broke the [react-select](https://github.com/JedWatson/react-select) package because authors have bug there and open [issue](JedWatson/react-select#165).

Because of my fixes I had a need to rewrite the test a little bit, so I hope that you'll have a look and tell me if you like it or not.

Waiting for the feedback!)

