### PR TITLE
(fix) Peer dependencies issue related to React v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "rollup-plugin-uglify": "^6.0.3"
   },
   "peerDependencies": {
-    "react": "^16.8.1 || ^17",
-    "react-dom": "^16.8.1 || ^17"
+    "react": "^16.8.1 || ^17 || ^18",
+    "react-dom": "^16.8.1 || ^17 || ^18"
   },
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
This PR fixed the issue occurring in some environments while installing this package.

```
22:53:01.146 | npm ERR! Could not resolve dependency:
22:53:01.146 | npm ERR! peer react@"^16.8.1 \|\| ^17" from react-alert@7.0.3
22:53:01.146 | npm ERR! node_modules/react-alert
22:53:01.146 | npm ERR!   react-alert@"^7.0.3" from the root project
```